### PR TITLE
decode encoded url before accessing file

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function (rules, options) {
 
   function isCleanUrl (pathname, rules) {
     
-    var p = pathname + '.html';
+    var p = decodeURIComponent(pathname + '.html');
     
     return pathMatchesRules(p, rules) && fileExists(p, {root: root});
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-urls",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Express/Connect middleware to serve static files from cleaner, extensionless urls",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Adds support for unicode filenames.

example:
url: http://localhost/det-här-är-ett-test
http request uri: det-h%C3%A4r-%C3%A4r-ett-test
file: det-här-är-ett-test.html

Before this change, clean-urls would look for det-h%C3%A4r-%C3%A4r-ett-test.html, which doesn't exist.
